### PR TITLE
Feat: 리스트 조회 api 응답/로그인 api 응답에 page 정보/사용자 정보 추가

### DIFF
--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/auth/AuthController.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/auth/AuthController.kt
@@ -1,7 +1,7 @@
 package com.example.tleapplication.application.auth
 
 import com.example.tleapplication.domain.auth.AuthService
-import com.example.tleapplication.domain.auth.UserToken
+import com.example.tleapplication.domain.auth.SignInInfo
 import com.example.tleapplication.support.logging.TraceIdResolver
 import com.example.tleapplication.support.response.TleApiResponse
 import com.example.tleapplication.support.security.Auth
@@ -35,12 +35,12 @@ class AuthController(
     )
     @PostMapping("/sign-in")
     @ResponseStatus(HttpStatus.OK)
-    fun signIn(@Valid @RequestBody authRequest: AuthRequest): TleApiResponse<UserToken> {
-        val userToken = authService.signIn(authRequest.code)
+    fun signIn(@Valid @RequestBody authRequest: AuthRequest): TleApiResponse<SignInInfo> {
+        val signInInfo = authService.signIn(authRequest.code)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = userToken
+            body = signInInfo
         )
     }
 

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/bookmark/BookmarkController.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/bookmark/BookmarkController.kt
@@ -101,13 +101,11 @@ class BookmarkController(
         @Parameter(name = "page", description = "페이지 번호", required = true)
         @RequestParam(defaultValue = "1") page: Int
     ): TleApiResponse<BookmarkListResponse> {
-        val bookmarks = bookmarkService.getAllBookmarks(authInfo.userId, page)
-        val bookmarkResponseList = bookmarks.map { BookmarkResponse.from(it) }
-
+        val bookmarkPage = bookmarkService.getAllBookmarks(authInfo.userId, page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = BookmarkListResponse(bookmarkResponseList)
+            body = BookmarkListResponse.from(bookmarkPage)
         )
     }
 }

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/bookmark/BookmarkListResponse.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/bookmark/BookmarkListResponse.kt
@@ -1,5 +1,22 @@
 package com.example.tleapplication.application.bookmark
 
+import com.example.tleapplication.domain.bookmark.Bookmark
+import org.springframework.data.domain.Page
+
 data class BookmarkListResponse(
+    val totalPages: Int,
+    val currentPage: Int,
+    val totalElements: Long,
     val bookmarkList: List<BookmarkResponse>
-)
+) {
+    companion object {
+        fun from(bookmarkPage: Page<Bookmark>): BookmarkListResponse {
+            return BookmarkListResponse(
+                totalPages =  bookmarkPage.totalPages,
+                currentPage = bookmarkPage.number + 1,
+                totalElements = bookmarkPage.totalElements,
+                bookmarkList = bookmarkPage.content.map { BookmarkResponse.from(it) }
+            )
+        }
+    }
+}

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsController.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsController.kt
@@ -77,7 +77,7 @@ class NewsController(
 
     @Operation(
         summary = "카테고리 기준 뉴스 조회",
-        description = "뉴스 조회 API(전체 or 카테고리)",
+        description = "카테고리 기준 뉴스 조회 API",
         responses = [
             ApiResponse(responseCode = "200", description = "뉴스 조회 성공"),
             ApiResponse(responseCode = "500", description = "Internal Server Error", content = arrayOf(
@@ -88,17 +88,16 @@ class NewsController(
     @GetMapping("by-category")
     @ResponseStatus(HttpStatus.OK)
     fun getNewsByCategory(
-        @Parameter(name = "category", description = "카테고리", required = false)
-        @RequestParam(required = false) category: Category?,
+        @Parameter(name = "category", description = "카테고리", required = true)
+        @RequestParam(required = true) category: Category,
         @Parameter(name = "page", description = "페이지 번호", required = true)
         @RequestParam(defaultValue = "1") page: Int
     ): TleApiResponse<NewsListResponse> {
-        val newsList = newsService.getNewsByCategory(category, page)
-        val newsResponseList = newsList.stream().map { NewsResponse.from(it) }.toList()
+        val newsPage = newsService.getNewsByCategory(category, page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = NewsListResponse(newsResponseList)
+            body = NewsListResponse.from(newsPage)
         )
     }
 
@@ -124,12 +123,11 @@ class NewsController(
         val formattedDate = date?.let {
             LocalDate.parse(it, formatter)
         }
-        val newsList = newsService.getNewsByDate(formattedDate, page)
-        val newsResponseList = newsList.stream().map { NewsResponse.from(it) }.toList()
+        val newsPage= newsService.getNewsByDate(formattedDate, page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = NewsListResponse(newsResponseList)
+            body = NewsListResponse.from(newsPage)
         )
     }
 
@@ -151,12 +149,11 @@ class NewsController(
         @Parameter(name = "page", description = "페이지 번호", required = true)
         @RequestParam(defaultValue = "1") page: Int
     ): TleApiResponse<NewsListResponse>  {
-        val newsList = newsService.searchNewsByKeyword(keyword, page)
-        val newsResponseList = newsList.stream().map { NewsResponse.from(it) }.toList()
+        val newsPage = newsService.searchNewsByKeyword(keyword, page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = NewsListResponse(newsResponseList)
+            body = NewsListResponse.from(newsPage)
         )
     }
 
@@ -176,12 +173,11 @@ class NewsController(
         @Parameter(name = "page", description = "페이지 번호", required = true)
         @RequestParam(defaultValue = "1") page: Int
     ): TleApiResponse<NewsListResponse> {
-        val newsList = newsService.getAllNews(page)
-        val newsResponseList = newsList.stream().map { NewsResponse.from(it) }.toList()
+        val newsPage = newsService.getAllNews(page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = NewsListResponse(newsResponseList)
+            body = NewsListResponse.from(newsPage)
         )
     }
 }

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsController.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsController.kt
@@ -23,7 +23,16 @@ class NewsController(
     private val newsService: NewsService,
     private val traceIdResolver: TraceIdResolver
 ) {
-
+    @Operation(
+        summary = "뉴스 개별 등록",
+        description = "뉴스 개별 등록 API",
+        responses = [
+            ApiResponse(responseCode = "201", description = "뉴스 등록 성공"),
+            ApiResponse(responseCode = "500", description = "Internal Server Error", content = arrayOf(
+                Content(schema = Schema(hidden = true))
+            )),
+        ],
+    )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun registerNews(
@@ -38,6 +47,16 @@ class NewsController(
         )
     }
 
+    @Operation(
+        summary = "뉴스 벌크 등록",
+        description = "뉴스 벌크 등록 API",
+        responses = [
+            ApiResponse(responseCode = "201", description = "뉴스 등록 성공"),
+            ApiResponse(responseCode = "500", description = "Internal Server Error", content = arrayOf(
+                Content(schema = Schema(hidden = true))
+            )),
+        ],
+    )
     @PostMapping("/bulk")
     @ResponseStatus(HttpStatus.CREATED)
     fun registerBulkNews(

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsListResponse.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/news/NewsListResponse.kt
@@ -1,6 +1,22 @@
 package com.example.tleapplication.application.news
 
+import com.example.tleapplication.domain.news.News
+import org.springframework.data.domain.Page
+
 data class NewsListResponse(
+    val totalPages: Int,
+    val currentPage: Int,
+    val totalElements: Long,
     val newsList: List<NewsResponse>
 ) {
+    companion object {
+        fun from(newsPage: Page<News>): NewsListResponse {
+            return NewsListResponse(
+                totalPages = newsPage.totalPages,
+                currentPage = newsPage.number + 1,
+                totalElements = newsPage.totalElements,
+                newsList = newsPage.content.map { NewsResponse.from(it)}
+            )
+        }
+    }
 }

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/scrap/ScrapController.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/scrap/ScrapController.kt
@@ -139,13 +139,11 @@ class ScrapController(
         @Parameter(name = "page", description = "페이지 번호", required = true)
         @RequestParam(defaultValue = "1") page: Int
     ): TleApiResponse<ScrapListResponse> {
-        val scraps = scrapService.getAllScraps(authInfo.userId, page)
-        val scrapResponseList = scraps.map { ScrapResponse.from(it) }
-
+        val scrapPage = scrapService.getAllScraps(authInfo.userId, page)
         return TleApiResponse.success(
             traceId = traceIdResolver.getTraceId(),
             status = HttpStatus.OK,
-            body = ScrapListResponse(scrapResponseList)
+            body = ScrapListResponse.from(scrapPage)
         )
     }
 }

--- a/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/scrap/ScrapListResponse.kt
+++ b/tle/tle-application/src/main/kotlin/com/example/tleapplication/application/scrap/ScrapListResponse.kt
@@ -1,5 +1,22 @@
 package com.example.tleapplication.application.scrap
 
+import com.example.tleapplication.domain.scrap.Scrap
+import org.springframework.data.domain.Page
+
 data class ScrapListResponse(
+    val totalPages: Int,
+    val currentPage: Int,
+    val totalElements: Long,
     val scrapList: List<ScrapResponse>
-)
+) {
+    companion object {
+        fun from(scrapPage: Page<Scrap>): ScrapListResponse {
+            return ScrapListResponse(
+                totalPages = scrapPage.totalPages,
+                currentPage = scrapPage.number + 1,
+                totalElements = scrapPage.totalElements,
+                scrapList = scrapPage.content.map { ScrapResponse.from(it) }
+            )
+        }
+    }
+}

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/AuthService.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/AuthService.kt
@@ -15,7 +15,7 @@ class AuthService(
     private val tokenIssuer: TokenIssuer
 ) {
     @Transactional
-    fun signIn(code: String): UserToken {
+    fun signIn(code: String): SignInInfo {
         val kakaoAccessToken = kakaoService.getAccessToken(code)
         val userInfo = kakaoService.getUserInfo(kakaoAccessToken)
 
@@ -35,7 +35,7 @@ class AuthService(
         user.updateRefreshToken(userToken.refreshToken)
         userService.saveUser(user)
 
-        return userToken
+        return SignInInfo.of(userToken, user)
     }
 
     @Transactional

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/AuthService.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/AuthService.kt
@@ -24,6 +24,7 @@ class AuthService(
         if (user == null) {
             user = User(
                 userInfo.id,
+                userInfo.kakaoAccount.email,
                 userInfo.kakaoAccount.profile.nickname,
                 userInfo.kakaoAccount.profile.profileImageUrl,
                 UserRoleEnum.ROLE_USER,

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/SignInInfo.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/SignInInfo.kt
@@ -5,7 +5,7 @@ import com.example.tleapplication.domain.user.User
 data class SignInInfo(
     val userToken: UserToken,
     val nickname: String,
-    val email: String?,
+    val email: String,
     val profileImage: String
 ) {
     companion object {

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/SignInInfo.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/auth/SignInInfo.kt
@@ -1,0 +1,21 @@
+package com.example.tleapplication.domain.auth
+
+import com.example.tleapplication.domain.user.User
+
+data class SignInInfo(
+    val userToken: UserToken,
+    val nickname: String,
+    val email: String?,
+    val profileImage: String
+) {
+    companion object {
+        fun of(userToken: UserToken, user: User): SignInInfo {
+            return SignInInfo(
+                userToken = userToken,
+                nickname = user.nickname,
+                email = user.email,
+                profileImage = user.profileImage
+            )
+        }
+    }
+}

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/bookmark/BookmarkRepository.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/bookmark/BookmarkRepository.kt
@@ -2,11 +2,12 @@ package com.example.tleapplication.domain.bookmark
 
 import com.example.tleapplication.domain.news.News
 import com.example.tleapplication.domain.user.User
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface BookmarkRepository {
     fun findBookmarkByUserAndNews(userId: Long, newsId: Long): Bookmark?
-    fun findAllBookmarks(userId: Long, pageable: Pageable): List<Bookmark>
+    fun findAllBookmarks(userId: Long, pageable: Pageable): Page<Bookmark>
     fun save(bookmark: Bookmark, user: User, news: News): Bookmark
     fun delete(id: Long)
 }

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/bookmark/BookmarkService.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/bookmark/BookmarkService.kt
@@ -7,6 +7,7 @@ import com.example.tleapplication.domain.user.UserService
 import com.example.tleapplication.support.exception.bookmark.BookmarkAlreadyExistsException
 import com.example.tleapplication.support.exception.news.NewsNotFoundException
 import com.example.tleapplication.support.exception.user.UserNotFoundException
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -36,7 +37,7 @@ class BookmarkService(
         bookmarkRepository.delete(id)
     }
 
-    fun getAllBookmarks(userId: Long, page: Int): List<Bookmark> {
+    fun getAllBookmarks(userId: Long, page: Int): Page<Bookmark> {
         val pageable = PageRequest.of(page - 1, NewsService.PAGE_SIZE)
 
         return bookmarkRepository.findAllBookmarks(userId, pageable)

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/kakao/KakaoUserInfo.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/kakao/KakaoUserInfo.kt
@@ -11,6 +11,9 @@ data class KakaoUserInfo(
     val kakaoAccount: KakaoAccount
 ) {
     data class KakaoAccount(
+        @JsonProperty("email")
+        val email: String,
+
         @JsonProperty("profile")
         val profile: Profile
     ) {

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/news/NewsRepository.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/news/NewsRepository.kt
@@ -1,17 +1,17 @@
 package com.example.tleapplication.domain.news
 
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Repository
 interface NewsRepository {
     fun save(news: News)
     fun saveAll(bulkNews: List<News>)
-    fun findNewsByCategory(category: Category, pageable: Pageable): List<News>
-    fun findAllNews(pageable: Pageable): List<News>
-    fun findNewsByDate(date: LocalDate, pageable: Pageable): List<News>
-    fun searchNewsByKeyword(keyword: String, pageable: Pageable): List<News>
+    fun findNewsByCategory(category: Category, pageable: Pageable): Page<News>
+    fun findAllNews(pageable: Pageable): Page<News>
+    fun findNewsByDate(date: LocalDate, pageable: Pageable): Page<News>
+    fun searchNewsByKeyword(keyword: String, pageable: Pageable): Page<News>
     fun findNewsById(id: Long): News?
 }

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/news/NewsService.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/news/NewsService.kt
@@ -1,6 +1,7 @@
 package com.example.tleapplication.domain.news
 
 import com.example.tleapplication.support.exception.news.NewsNotFoundException
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,30 +29,26 @@ class NewsService(
         return findNewsById(id) ?: throw NewsNotFoundException()
     }
 
-    fun getNewsByCategory(category: Category?, page: Int): List<News> {
+    fun getNewsByCategory(category: Category, page: Int): Page<News> {
         val pageable = PageRequest.of(page - 1, PAGE_SIZE)
 
-        return if (category != null) {
-            newsRepository.findNewsByCategory(category, pageable)
-        } else {
-            newsRepository.findAllNews(pageable)
-        }
+        return newsRepository.findNewsByCategory(category, pageable)
     }
 
-    fun getNewsByDate(date: LocalDate?, page: Int): List<News> {
+    fun getNewsByDate(date: LocalDate?, page: Int): Page<News> {
         val pageable = PageRequest.of(page - 1, PAGE_SIZE)
         val targetDate = date ?: LocalDate.now()
 
         return newsRepository.findNewsByDate(targetDate, pageable)
     }
 
-    fun getAllNews(page: Int): List<News> {
+    fun getAllNews(page: Int): Page<News> {
         val pageable = PageRequest.of(page - 1, PAGE_SIZE)
 
         return newsRepository.findAllNews(pageable)
     }
 
-    fun searchNewsByKeyword(keyword: String, page: Int): List<News> {
+    fun searchNewsByKeyword(keyword: String, page: Int): Page<News> {
         val pageable = PageRequest.of(page - 1, PAGE_SIZE)
         return newsRepository.searchNewsByKeyword(keyword, pageable)
     }

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/scrap/ScrapRepository.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/scrap/ScrapRepository.kt
@@ -2,6 +2,7 @@ package com.example.tleapplication.domain.scrap
 
 import com.example.tleapplication.domain.news.News
 import com.example.tleapplication.domain.user.User
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
@@ -10,7 +11,7 @@ interface ScrapRepository {
     fun save(scrap: Scrap, user: User, news: News): Scrap
     fun findScrapByUserAndNews(userId: Long, newsId: Long): Scrap?
     fun findScrapById(id: Long): Scrap
-    fun findAllScraps(userId: Long, pageable: Pageable): List<Scrap>
+    fun findAllScraps(userId: Long, pageable: Pageable): Page<Scrap>
     fun update(scrap: Scrap): Scrap
     fun delete(id: Long)
 }

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/scrap/ScrapService.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/scrap/ScrapService.kt
@@ -7,6 +7,7 @@ import com.example.tleapplication.domain.user.UserService
 import com.example.tleapplication.support.exception.news.NewsNotFoundException
 import com.example.tleapplication.support.exception.scrap.ScrapAlreadyExistsException
 import com.example.tleapplication.support.exception.user.UserNotFoundException
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -36,7 +37,7 @@ class ScrapService(
         return scrap
     }
 
-    fun getAllScraps(userId: Long, page: Int): List<Scrap> {
+    fun getAllScraps(userId: Long, page: Int): Page<Scrap> {
         val pageable = PageRequest.of(page - 1, NewsService.PAGE_SIZE)
 
         return scrapRepository.findAllScraps(userId, pageable)

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/user/User.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/user/User.kt
@@ -2,7 +2,7 @@ package com.example.tleapplication.domain.user
 
 data class User(
     val id: Long,
-    var nickName: String,
+    var nickname: String,
     var profileImage: String,
     var role: UserRoleEnum,
     var kakaoAccessToken: String?,

--- a/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/user/User.kt
+++ b/tle/tle-domain/src/main/kotlin/com/example/tleapplication/domain/user/User.kt
@@ -2,11 +2,11 @@ package com.example.tleapplication.domain.user
 
 data class User(
     val id: Long,
+    val email: String,
     var nickname: String,
     var profileImage: String,
     var role: UserRoleEnum,
     var kakaoAccessToken: String?,
-    var email: String? = null,
     var refreshToken: String? = null
 ) {
     fun updateRefreshToken(refreshToken: String) {

--- a/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/bookmark/BookmarkRepositoryImpl.kt
+++ b/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/bookmark/BookmarkRepositoryImpl.kt
@@ -32,10 +32,9 @@ class BookmarkRepositoryImpl(
         bookmarkJpaRepository.delete(bookmarkEntity)
     }
 
-    override fun findAllBookmarks(userId: Long, pageable: Pageable): List<Bookmark> {
-        val bookmarkEntities = bookmarkJpaRepository.findAllByUserId(userId, pageable)
-
-        return bookmarkEntities.map { it.toDomain() }.toList()
+    override fun findAllBookmarks(userId: Long, pageable: Pageable): Page<Bookmark> {
+        val bookmarkPage = bookmarkJpaRepository.findAllByUserId(userId, pageable).map { it.toDomain() }
+        return bookmarkPage
     }
 }
 

--- a/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/news/NewsRepositoryImpl.kt
+++ b/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/news/NewsRepositoryImpl.kt
@@ -27,24 +27,20 @@ class NewsRepositoryImpl(
         newsJpaRepository.saveAll(bulkNewsEntity)
     }
 
-    override fun findNewsByCategory(category: Category, pageable: Pageable): List<News> {
-        return newsJpaRepository.findByCategory(category, pageable).content
-            .stream().map { it.toDomain() }.toList()
+    override fun findNewsByCategory(category: Category, pageable: Pageable): Page<News> {
+        return newsJpaRepository.findByCategory(category, pageable).map { it.toDomain() }
     }
 
-    override fun findAllNews(pageable: Pageable): List<News> {
-        return newsJpaRepository.findAll(pageable).content
-            .stream().map { it.toDomain() }.toList()
+    override fun findAllNews(pageable: Pageable): Page<News> {
+        return newsJpaRepository.findAll(pageable).map { it.toDomain() }
     }
 
-    override fun findNewsByDate(date: LocalDate, pageable: Pageable): List<News> {
-        return newsJpaRepository.findByPublishedAt(date, pageable).content
-            .stream().map { it.toDomain() }.toList()
+    override fun findNewsByDate(date: LocalDate, pageable: Pageable): Page<News> {
+        return newsJpaRepository.findByPublishedAt(date, pageable).map { it.toDomain() }
     }
 
-    override fun searchNewsByKeyword(keyword: String, pageable: Pageable): List<News> {
-        return newsJpaRepository.searchByKeyword(keyword, pageable).content
-            .stream().map { it.toDomain() }.toList()
+    override fun searchNewsByKeyword(keyword: String, pageable: Pageable): Page<News> {
+        return newsJpaRepository.searchByKeyword(keyword, pageable).map { it.toDomain() }
     }
 
     override fun findNewsById(id: Long): News? {

--- a/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/scrap/ScrapRepositoryImpl.kt
+++ b/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/scrap/ScrapRepositoryImpl.kt
@@ -55,9 +55,9 @@ class ScrapRepositoryImpl(
         scrapJpaRepository.save(scrapEntity)
     }
 
-    override fun findAllScraps(userId: Long, pageable: Pageable): List<Scrap> {
-        val scrapEntities = scrapJpaRepository.findAllByUserId(userId, pageable)
-        return scrapEntities.map { it.toDomain() }.toList()
+    override fun findAllScraps(userId: Long, pageable: Pageable): Page<Scrap> {
+        val scrapPage = scrapJpaRepository.findAllByUserId(userId, pageable).map { it.toDomain() }
+        return scrapPage
     }
 }
 

--- a/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/user/UserEntity.kt
+++ b/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/user/UserEntity.kt
@@ -23,7 +23,7 @@ class UserEntity(
     val id: Long,
 
     @Column(length = 64, name = "email", unique = true)
-    var email: String?,
+    var email: String,
 
     @Column(length = 64, name = "nick_name", unique = true)
     var nickName: String,

--- a/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/user/UserEntity.kt
+++ b/tle/tle-storage/src/main/kotlin/com/example/tleapplication/storage/user/UserEntity.kt
@@ -45,7 +45,7 @@ class UserEntity(
             return UserEntity(
                 id = user.id,
                 email = user.email,
-                nickName = user.nickName,
+                nickName = user.nickname,
                 kakaoAccessToken = user.kakaoAccessToken,
                 refreshToken = user.refreshToken,
                 profileImage = user.profileImage,
@@ -57,7 +57,7 @@ class UserEntity(
     fun toDomain(): User {
         return User(
             id = this.id,
-            nickName = this.nickName,
+            nickname = this.nickName,
             profileImage = this.profileImage,
             role = this.role,
             kakaoAccessToken = this.kakaoAccessToken,


### PR DESCRIPTION
## 작업분류

- [ ] 버그 수정
- [X] 신규 기능
- [ ] 리팩터링
- [ ] 기타

## 작업개요

> 주요 작업 내용에 대한 요약설명

## 작업 상세 내용

> 작업 개요에 작성한 작업 내용에 대한 상세 항목
- pagination을 적용한 모든 리스트 조회 api 응답에 page 정보(총 페이지 개수, 현재 페이지 번호, 총 데이터 개수)를 추가하였습니다.
- sign-in api 응답에 사용자 정보(닉네임, 이메일, 프로필사진 url)를 추가하였습니다.

## 리뷰 요구사항

> 집중 리뷰 부분 작성

## 기타

> 관련 이슈 연결, 테스트 결과 첨부 etc.
